### PR TITLE
Fix local hitsound priority

### DIFF
--- a/source/src/audiomanager.cpp
+++ b/source/src/audiomanager.cpp
@@ -770,9 +770,12 @@ bool staticreference::operator==(const worldobjreference &other)
 
 audiomanager audiomgr;
 
-COMMANDF(sound, "i", (int *n)
+const char *prioritynames[] = {"LOW", "NORMAL", "HIGH", "HIGHEST", ""};
+
+COMMANDF(sound, "is", (int *n, char *priorityname)
 {
-    audiomgr.playsound(*n);
+    int priority = getlistindex(priorityname, prioritynames, true, SP_NORMAL);
+    audiomgr.playsound(*n, priority);
 });
 
 COMMANDF(applymapsoundchanges, "", (){


### PR DESCRIPTION
## Original issue

#121

## Description

Local hitsounds (/hitsound 2) [work](https://github.com/ActionFPS/ActionFPS-Game/blob/7d660426c9f93ed962b102701b7b81694cf1c105/source/src/weapon.cpp#L407) by running CubeScript command `sound`, passing hitsound sound number and
priority (highest). However, `sound` command doesn't actually
take the second priority argument and always uses default normal
priority.

This commit adds the second priority argument to `sound`.
It accepts numeric priority levels as well as string names.

## Check List

* [ ] Tests written - not really (are there any?)
* [x] Locally tested - yup
* [ ] Documented well enough - I can add docs for the new argument to `config/docs.cfg` but it asks to edit `docs/reference.xml` which does not exist, what do I do?

P.S.: do I need to create related issues for minor bugfixes like this?