### PR TITLE
Bind fullscreen toggle to F11 by default

### DIFF
--- a/config/resetbinds.cfg
+++ b/config/resetbinds.cfg
@@ -195,8 +195,8 @@ editbind F7 [ if $fullbright [ fullbright 0 ] [ fullbright 1 ] ]
 bind F8 []
 editbind F8 showfocuscubedetails
 bind F9 []
-bind F10 key_getdemo
-bind F11 key_toggleconsole
+bind F10 key_toggleconsole
+bind F11 fullscreentoggle
 bind F12 screenshot
 bind F13 []
 bind F14 []


### PR DESCRIPTION
## Original issue

#111

## Description

Bind fullscreen toggle to F11 by default and move console toggle to F10, removing default demo download bind.

## How do we know this works?

Tested on a fresh install and after resetting to default binds.

## Check List

* [x] Locally tested
