### PR TITLE
Fix non-standalone server misinterpreting intro packet

### DIFF
--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -2756,14 +2756,18 @@ void process(ENetPacket *packet, int sender, int chan)
 
 #ifdef STANDALONE
             bool successful_authentication = false;
-            if(signature.len)
-            {
-                p.get(signature.buf, signature.len);
-                successful_authentication = usermanager.check_authentication(cl, uid, signature);
-            }
 #else
             bool successful_authentication = true;
 #endif
+
+            if(signature.len)
+            {
+                p.get(signature.buf, signature.len);
+#ifdef STANDALONE
+                successful_authentication = usermanager.check_authentication(cl, uid, signature);
+#endif
+            }
+
             signature.reset();
 
             if(!successful_authentication)


### PR DESCRIPTION
## Original issue

Bug discussed in Discord: debug build client would randomly crash on load, on normal build
random messages like `can't delete map <random hex chars>: no permissions` could occur.

## Description

Client always sends signature length + signature itself in intro packet
(first packet upon connection), so the server should always read it
even when it doesn't need it in non-standalone mode.

The bug caused non-standalone server to interpret signature body
as normal messages, causing assertion failure in debug mode
and random, mostly harmless, actions in normal build.

## How do we know this works?

Debug client no longer crashes on load.

## Check List

* [x] Locally tested
