### PR TITLE
Fix server sending bad saved scores

### DIFF
--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -2442,6 +2442,7 @@ void senddisconnectedscores(int cn)
             {
                 putint(p, sc.team);
                 sendstring(sc.name, p);
+                sendstring(sc.userid, p);
                 putint(p, sc.flagscore);
                 putint(p, sc.frags);
                 putint(p, sc.deaths);


### PR DESCRIPTION
## Original issue

#123

## Description

Client expects a sequence of saved scores, terminated by
a saved score with team id -1. Among the fields that it expects
in each saved score is user id, which server does not send.
Consequently, client will interpret some other fields as
user id. If that data includes terminating -1, it will
enter infinite loop, reading score records from past the
packet end and eventually crashing when out of memory.

The solution is for server to send user id, as client expects.

Code reference: [server sending](https://github.com/ActionFPS/ActionFPS-Game/blob/c747f39f5d8e47e1fc5660f7c334e4212415a596/source/src/server.cpp#L2432-L2454), [client receiving](https://github.com/ActionFPS/ActionFPS-Game/blob/c747f39f5d8e47e1fc5660f7c334e4212415a596/source/src/clients2c.cpp#L900-L918).

## How do we know this works?

I was able to watch the demo without crashing after removing userid reading from client, sending userid from server should work, too, and also restore userid correctly.

## Check List

* [ ] Locally tested
