### PR TITLE
Saved scores fixes.

### DIFF
--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -2528,7 +2528,7 @@ bool restorescore(client &c)
     savedscore *sc = findscore(c, false);
     if(sc && sc->valid)
     {
-        sc->restore(c.state);
+        sc->restore(c);
         sc->valid = false;
         if ( c.connectmillis - c.state.lastdisc < 5000 ) c.state.reconnections++;
         else if ( c.state.reconnections ) c.state.reconnections--;

--- a/source/src/server.h
+++ b/source/src/server.h
@@ -357,7 +357,7 @@ struct savedscore
         events = c.state.events;
         lastdisc = c.state.lastdisc;
         reconnections = c.state.reconnections;
-        team = c.t;
+        team = c.team;
         copystring(userid, c.userid);
         copystring(identity, c.identity);
         valid = true;
@@ -377,6 +377,12 @@ struct savedscore
         cs.lastdisc = lastdisc;
         cs.reconnections = reconnections;
         reset();
+    }
+
+    void restore(client &c)
+    {
+        restore(c.state);
+        c.team = team;
     }
 };
 

--- a/source/src/server.h
+++ b/source/src/server.h
@@ -363,26 +363,21 @@ struct savedscore
         valid = true;
     }
 
-    void restore(clientstate &cs)
-    {
-        cs.frags = frags;
-        cs.flagscore = flagscore;
-        cs.deaths = deaths;
-        cs.teamkills = teamkills;
-        cs.shotdamage = shotdamage;
-        cs.damage = damage;
-        cs.points = points;
-        cs.forced = forced;
-        cs.events = events;
-        cs.lastdisc = lastdisc;
-        cs.reconnections = reconnections;
-        reset();
-    }
-
     void restore(client &c)
     {
-        restore(c.state);
+        c.state.frags = frags;
+        c.state.flagscore = flagscore;
+        c.state.deaths = deaths;
+        c.state.teamkills = teamkills;
+        c.state.shotdamage = shotdamage;
+        c.state.damage = damage;
+        c.state.points = points;
+        c.state.forced = forced;
+        c.state.events = events;
+        c.state.lastdisc = lastdisc;
+        c.state.reconnections = reconnections;
         c.team = team;
+        reset();
     }
 };
 


### PR DESCRIPTION
## Original issue

* #137 

## Description

Attempt to fix various issues with saved scores, which are used to restore user data (team and scores) upon reconnection.

## Check List

* [x] Locally tested
