### PR TITLE
no librt on openbsd

### DIFF
--- a/source/src/Makefile
+++ b/source/src/Makefile
@@ -118,7 +118,10 @@ SERVER_INCLUDES= -DSTANDALONE $(INCLUDES) -I../include
 SERVER_LIBS= -L../lib -lzdll -lenet -lws2_32 -lwinmm
 else
 SERVER_INCLUDES= -DSTANDALONE $(INCLUDES)
-SERVER_LIBS= -L../enet/.libs -lenet -lz -lpthread -lrt -lssl -lcrypto
+SERVER_LIBS= -L../enet/.libs -lenet -lz -lpthread -lssl -lcrypto
+ifneq (,$(findstring OpenBSD,$(PLATFORM)))
+SERVER_LIBS+= -lrt
+endif
 endif
 
 SERVER_OBJS= \


### PR DESCRIPTION
Delete where appropriate 

## Original issue

Link here

## Description

Tried to build on OpenBSD, the only curlprit in the linkage time with -lrt flag which is not on OpenBSD but Linux, possibly FreeBSD ...

## How do we know this works?


## Check List

* [ ] Tests written (if appropriate)
* [* ] Locally tested
* [ ] Documented well enough
