### PR TITLE
refactored the findscore function

### DIFF
--- a/source/src/server.h
+++ b/source/src/server.h
@@ -333,6 +333,7 @@ struct client                   // server side version of "dynent" type
 
 struct savedscore
 {
+    int clientnum;
     string name;
     string userid;
     string identity;
@@ -349,6 +350,7 @@ struct savedscore
 
     void save(client &c)
     {
+        clientnum = c.clientnum;
         frags = c.state.frags;
         flagscore = c.state.flagscore;
         deaths = c.state.deaths;


### PR DESCRIPTION
- The function was refactored to:
  1. If the client is not TCP/IP or is not authenticated, then return;
  2. Search for a savedscore for the client before inserting a new one;
  3. If there is no scoreboard for the client and the flag isToInsert is
     true, then it'll create a scoreboard for the client, otherwise
     it'll return;
- Added the field clientnum in the scoreboard, because this field is more
  robust to avoid conflict with clients;

## Original issue

https://github.com/ActionFPS/ActionFPS-Game/issues/144

## Description

There was a weak comparison between clients in the findscore function, this comparison leaded the server to reconnect the new client, instead of properly initialize it.

## How do we know this works?

Follow the reproduction list in the issue description.

## Check List

* [ ] Tests written (if appropriate)
* [ x ] Locally tested
* [ ] Documented well enough
